### PR TITLE
update AMI IDs

### DIFF
--- a/terraform-templates/vars.tf
+++ b/terraform-templates/vars.tf
@@ -50,10 +50,10 @@ variable "ami" {
   # https://aws.amazon.com/marketplace/ordering?productId=4ce33fd9-63ff-4f35-8d3a-939b641f1931. Note that the very first
   # time, you have to accept the terms and conditions on that page or the EC2 instances will fail to launch!
   default = {
-    us-east-1 = "ami-a98cb2c3"
-    us-west-1 = "ami-bafd8dda"
-    eu-central-1 = "ami-376c8958"
-    eu-west-1 = "ami-2989375a"
+    us-east-1     = "ami-5d1b984a"
+    us-west-1     = "ami-e4b5f384"
+    eu-central-1  = "ami-c9f603a6"
+    eu-west-1     = "ami-64385917"
   }
 }
 

--- a/terraform-templates/vars.tf
+++ b/terraform-templates/vars.tf
@@ -50,10 +50,10 @@ variable "ami" {
   # https://aws.amazon.com/marketplace/ordering?productId=4ce33fd9-63ff-4f35-8d3a-939b641f1931. Note that the very first
   # time, you have to accept the terms and conditions on that page or the EC2 instances will fail to launch!
   default = {
-    us-east-1     = "ami-5d1b984a"
-    us-west-1     = "ami-e4b5f384"
-    eu-central-1  = "ami-c9f603a6"
-    eu-west-1     = "ami-64385917"
+    us-east-1     = "ami-55870742"
+    us-west-1     = "ami-07713767"
+    eu-central-1  = "ami-3b54be54"
+    eu-west-1     = "ami-c74127b4"
   }
 }
 


### PR DESCRIPTION
Thanks for putting together this example!

The latest AMI release shown on the [Marketplace page](https://aws.amazon.com/marketplace/ordering?productId=4ce33fd9-63ff-4f35-8d3a-939b641f19310) seems to be a patch version, which is why I think the IDs you used in March are now no longer available.

I have updated the IDs to use the `2016.03.e` release which, judging by the older AMIs with the same naming convention, should be available for at least a year.

I have tested the AMI in `us-east-1` by deploying the example app.

You can verify the IDs by searching for `amzn-ami-2016.03.e-amazon-ecs-optimized` on the [EC2 AMI page](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Images:visibility=public-images;search=amzn-ami-2016.03.e-amazon-ecs-optimized;sort=name).
