### PR TITLE
Oct2016 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,14 @@
 /.bundle
 
 # Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
+rails-frontend/db/*.sqlite3
+rails-frontend/db/*.sqlite3-journal
 
 # Ignore all logfiles and tempfiles.
 /log/*
 !/log/.keep
 /tmp
+rails-frontend/tmp
 
 # Rake files
 .generators

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ To deploy the microservices to your AWS account, see the [terraform-templates RE
 ## How to use your own Docker images
 
 By default, [docker-compose.yml](./docker-compose.yml) and the [terraform-templates](./terraform-templates) are using
-the `brikis98/rails-frontend` and `brikis98/sinatra-backend` Docker images. These are images I pushed to my [Docker
-Hub account](https://hub.docker.com/r/brikis98/rails-example-app/) to make it easy for you to try this repo quickly.
+the `gruntwork/rails-frontend` and `gruntwork/sinatra-backend` Docker images. These are images I pushed to the [Gruntwork Docker
+Hub account](https://hub.docker.com/r/gruntwork/rails-example-app/) to make it easy for you to try this repo quickly.
 Obviously, in the real world, you'll want to use your own images instead.
 
 Follow Docker's documentation to [create your own Docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 rails_frontend:
-  image: brikis98/rails-frontend
+  image: gruntwork/rails-frontend
   volumes:
     - ./rails-frontend:/usr/src/app
   ports:
@@ -10,7 +10,7 @@ rails_frontend:
     - sinatra_backend:sinatra_backend
 
 sinatra_backend:
-  image: brikis98/sinatra-backend
+  image: gruntwork/sinatra-backend
   volumes:
     - ./sinatra-backend:/usr/src/app
   ports:

--- a/rails-frontend/Dockerfile
+++ b/rails-frontend/Dockerfile
@@ -1,5 +1,5 @@
 FROM rails:4.2.6
-MAINTAINER Yevgeniy Brikman <jim@ybrikman.com>
+MAINTAINER Gruntwork <info@gruntwork.io>
 
 # Source code should be in the /usr/src/app folder
 RUN mkdir -p /usr/src/app

--- a/sinatra-backend/Dockerfile
+++ b/sinatra-backend/Dockerfile
@@ -1,5 +1,5 @@
 FROM gliderlabs/alpine:3.4
-MAINTAINER Yevgeniy Brikman <jim@ybrikman.com>
+MAINTAINER Gruntwork <info@gruntwork.io>
 
 # Install Sinatra
 RUN apk --update upgrade &&\

--- a/sinatra-backend/Dockerfile
+++ b/sinatra-backend/Dockerfile
@@ -1,9 +1,11 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.4
 MAINTAINER Yevgeniy Brikman <jim@ybrikman.com>
 
 # Install Sinatra
-RUN apk --no-cache add ruby ruby-dev
-RUN gem install sinatra --no-ri --no-rdoc
+RUN apk --update upgrade &&\
+    apk --no-cache add curl ca-certificates &&\
+    apk --no-cache add ruby ruby-dev &&\
+    gem install sinatra --no-ri --no-rdoc
 
 # Source code should be in the /usr/src/app folder
 RUN mkdir -p /usr/src/app

--- a/terraform-templates/terraform.tfvars.sample
+++ b/terraform-templates/terraform.tfvars.sample
@@ -11,9 +11,9 @@ region = "us-east-1"
 
 # These are convenient images available in Docker Hub to test this application. To deploy your own images, fill in the
 # image names and versions here
-rails_frontend_image = "brikis98/rails-frontend"
+rails_frontend_image = "gruntwork/rails-frontend"
 rails_frontend_version = "v1"
-sinatra_backend_image = "brikis98/sinatra-backend"
+sinatra_backend_image = "gruntwork/sinatra-backend"
 sinatra_backend_version = "v1"
 
 # The name of a Key Pair that can be used to SSH to each EC2 instance. Use the AWS EC2 console to create the Key Pair:

--- a/terraform-templates/vars.tf
+++ b/terraform-templates/vars.tf
@@ -1,5 +1,5 @@
 variable "rails_frontend_image" {
-  description = "The name of the Docker image to deploy for the Rails frontend (e.g. brikis98/rails-frontend)"
+  description = "The name of the Docker image to deploy for the Rails frontend (e.g. gruntwork/rails-frontend)"
 }
 
 variable "rails_frontend_version" {
@@ -12,7 +12,7 @@ variable "rails_frontend_port" {
 }
 
 variable "sinatra_backend_image" {
-  description = "The name of the Docker image to deploy for the Sinatra backend (e.g. brikis98/sinatra-backend)"
+  description = "The name of the Docker image to deploy for the Sinatra backend (e.g. gruntwork/sinatra-backend)"
 }
 
 variable "sinatra_backend_version" {


### PR DESCRIPTION
- Replaced brikis98 references with gruntwork references (and setup corresponding gruntwork docker repos)
- Fixed issue where sinatra couldn't install due to CA cert issues. The whole point of the talk is now that they're fixed once, you don't have to bother again!

Time-permitting, I'll update the ELB references to ALB.
