### PR TITLE
Update docker-compose.yml to reference v1 tag, instead of defaulting to latest.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 rails_frontend:
-  image: gruntwork/rails-frontend
+  image: gruntwork/rails-frontend:v1
   volumes:
     - ./rails-frontend:/usr/src/app
   ports:
@@ -10,7 +10,7 @@ rails_frontend:
     - sinatra_backend:sinatra_backend
 
 sinatra_backend:
-  image: gruntwork/sinatra-backend
+  image: gruntwork/sinatra-backend:v1
   volumes:
     - ./sinatra-backend:/usr/src/app
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 rails_frontend:
-  image: gruntwork/rails-frontend:v1
+  image: gruntwork/rails-frontend
   volumes:
     - ./rails-frontend:/usr/src/app
   ports:
@@ -10,7 +10,7 @@ rails_frontend:
     - sinatra_backend:sinatra_backend
 
 sinatra_backend:
-  image: gruntwork/sinatra-backend:v1
+  image: gruntwork/sinatra-backend
   volumes:
     - ./sinatra-backend:/usr/src/app
   ports:

--- a/rails-frontend/Dockerfile
+++ b/rails-frontend/Dockerfile
@@ -12,7 +12,9 @@ RUN bundle install
 
 # Now copy the rest of the source code
 COPY . /usr/src/app
+RUN chmod +x /usr/src/app/docker-entrypoint.sh
 
 # Run the rails server by default
 EXPOSE 3000
+ENTRYPOINT ["bash","/usr/src/app/docker-entrypoint.sh"]
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/rails-frontend/docker-entrypoint.sh
+++ b/rails-frontend/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# This script is meant to be run as the "entrypoint" to the docker container. Its purpose is to delete any leftover
+# tmp files from previous docker-compose runs. It was copied from http://stackoverflow.com/a/38732187.
+#
+# Prior to using this entrypoing script, running "docker-compose up" would work the first time, but on subsequent runs,
+# I'd get the error "A server is already running. Check /usr/src/app/tmp/pids/server.pid." The issue is that the the 
+# /tmp folder is in the mounted volume and was being persisted when in fact we wanted it deleted after every run.
+# 
+# This script fixes that by first deleting the offending file in /tmp before starting. 
+
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+exec bundle exec "$@"


### PR DESCRIPTION
Simple change, but makes the `docker-compose.yml` work out of the box.

A few helpful tips with this:
1. As of Oct 12, 2016, `docker-compose up` is really slow on Docker beta for Mac. The fix is [here](https://github.com/docker/compose/issues/3419#issuecomment-221793401).
2. There's a known issue where the first run of `docker-compose up` is successful, but the second run fails because the files in `./rails-frontend/tmp` don't automatically get deleted when you `CTRL+C` docker-compose.

@brikis98 Any thought on a way to handle the second issue?

Also, I've pushed `v2` of the `sinatra-backend` to https://hub.docker.com/r/gruntwork/sinatra-backend.
